### PR TITLE
check for file exists before running command

### DIFF
--- a/recipes/install_backup.rb
+++ b/recipes/install_backup.rb
@@ -9,4 +9,4 @@ if File.exist?("#{node['percona']['backup']['sql']}") then
   execute "mysql-install-backup" do
     command "/usr/bin/mysql -u root -p'#{node['percona']['server']['root_password']}' #{node['percona']['backup']['db']} < #{node['percona']['backup']['sql']}"
   end
-fi
+end


### PR DESCRIPTION
Do a check that file exists  before importing sql (which doesn't exist on all nodes, thus causing them to fail)
